### PR TITLE
adding test plan result publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,26 @@ Settings file template cfg:
 	project_id = 1
 	suite_id = 1
 
+If you'd prefer to be using test runs, this is what your marker and setup would look like.
+
+	from pytest_testrail.plugin import suite_testrail
+
+	@suite_testrail('S123', 'C1234', 'C5678')
+	def test_foo():
+		# test code goes here
+
+Settings file template cfg:
+
+	[API]
+	url = https://yoururl.testrail.net/
+	email = user@email.com
+	password = password
+
+	[TESTRUN]
+	assignedto_id = 1
+	project_id = 1
+	use_plan = 1
+
 Usage
 -----
 	py.test --testrail=<settings file>.cfg

--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,30 @@ Settings file template cfg:
     project_id = 1
     suite_id = 1
 
+
+If you'd prefer to be using test runs, this is what your marker and setup would look like.
+::
+
+    from pytest_testrail.plugin import suite_testrail
+
+    @suite_testrail('S123', 'C1234', 'C5678')
+    def test_foo():
+        # test code goes here
+
+Settings file template cfg:
+
+::
+
+    [API]
+    url = https://yoururl.testrail.net/
+    email = user@email.com
+    password = password
+
+    [TESTRUN]
+    assignedto_id = 1
+    project_id = 1
+    use_plan = 1
+
 Usage
 -----
 

--- a/pytest_testrail/conftest.py
+++ b/pytest_testrail/conftest.py
@@ -1,4 +1,5 @@
 import configparser
+from configparser import NoOptionError
 
 from .plugin import TestRailPlugin
 from .testrail_api import APIClient
@@ -38,14 +39,29 @@ def pytest_configure(config):
         if config.getoption('--no-ssl-cert-check') is True:
             ssl_cert_check = False
 
+        try:
+            tmp = cfg_file.get('TESTRUN', 'use_plan')
+            if int(tmp) == 1:
+                use_testplan = True
+            else:
+                use_testplan = False
+        except NoOptionError:
+            use_testplan = False
+
+        try:
+            s_id = cfg_file.get('TESTRUN', 'suite_id')
+        except NoOptionError:
+            s_id = None
+
         config.pluginmanager.register(
             TestRailPlugin(
                 client=client,
                 assign_user_id=cfg_file.get('TESTRUN', 'assignedto_id'),
                 project_id=cfg_file.get('TESTRUN', 'project_id'),
-                suite_id=cfg_file.get('TESTRUN', 'suite_id'),
+                suite_id=s_id,
                 cert_check=ssl_cert_check,
-                tr_name=tr_name
+                tr_name=tr_name,
+                use_testplan=use_testplan
             )
         )
 

--- a/pytest_testrail/plugin.py
+++ b/pytest_testrail/plugin.py
@@ -11,9 +11,11 @@ PYTEST_TO_TESTRAIL_STATUS = {
 DT_FORMAT = '%d-%m-%Y %H:%M:%S'
 
 TESTRAIL_PREFIX = 'testrail'
+SUITE_PREFIX = 'suite_testrail'
 
 ADD_RESULTS_URL = 'add_results_for_cases/{}/'
 ADD_TESTRUN_URL = 'add_run/{}'
+ADD_TESTPLAN_URL = 'add_plan/{}'
 
 
 def testrail(*ids):
@@ -25,6 +27,16 @@ def testrail(*ids):
     :return pytest.mark:
     """
     return pytest.mark.testrail(ids=ids)
+
+
+def suite_testrail(suite_id, *ids):
+    """
+    Decorator to mark cases with the suite id and test case
+    i.e. @suite_testrail('S12', 'C123')
+    :param id:
+    :return: pytest.mark
+    """
+    return pytest.mark.suite_testrail(suite_id=suite_id, ids=ids)
 
 
 def get_test_outcome(outcome):
@@ -53,6 +65,16 @@ def clean_test_ids(test_ids):
     return map(int, [test_id.upper().replace('C', '') for test_id in test_ids])
 
 
+def clean_suite_ids(test_id):
+    """
+    Clean pytest marker containing testrail testcase ids.
+
+    :param test_id
+    :return an int
+    """
+    return int(test_id.upper().replace('S', ''))
+
+
 def get_testrail_keys(items):
     """Return TestRail ids from pytests markers"""
     testcaseids = []
@@ -66,33 +88,67 @@ def get_testrail_keys(items):
     return testcaseids
 
 
+def get_testrail_suite_and_keys(items):
+    """Return TestRail ids from pytests markers"""
+    suite_dict = {}
+    for item in items:
+        if item.get_marker(SUITE_PREFIX):
+            _suite_id = clean_suite_ids(
+                item.get_marker(SUITE_PREFIX).kwargs.get('suite_id')
+            )
+            if not suite_dict.has_key(_suite_id):
+                suite_dict[_suite_id] = []
+            # now get the test case numbers
+            suite_dict[_suite_id].extend(
+                clean_test_ids(
+                    item.get_marker(SUITE_PREFIX).kwargs.get('ids')
+                )
+            )
+    return suite_dict
+
+
 class TestRailPlugin(object):
     def __init__(
-            self, client, assign_user_id, project_id, suite_id, cert_check, tr_name):
+            self, client, assign_user_id, project_id, suite_id, cert_check, tr_name, use_testplan=False):
         self.assign_user_id = assign_user_id
         self.cert_check = cert_check
         self.client = client
         self.project_id = project_id
-        self.results = []
+        self.use_testplan = use_testplan
+        if self.use_testplan:
+            self.results = {}
+        else:
+            self.results = []
         self.suite_id = suite_id
         self.testrun_id = 0
+        self.testrun_ids = {}
         self.testrun_name = tr_name
+
 
     # pytest hooks
 
     @pytest.hookimpl(trylast=True)
     def pytest_collection_modifyitems(self, session, config, items):
-        tr_keys = get_testrail_keys(items)
         if self.testrun_name is None:
             self.testrun_name = testrun_name()
 
-        self.create_test_run(
-            self.assign_user_id,
-            self.project_id,
-            self.suite_id,
-            self.testrun_name,
-            tr_keys
-        )
+        if self.use_testplan:
+            tp_keys = get_testrail_suite_and_keys(items)
+            self.create_test_plan(
+                self.assign_user_id,
+                self.project_id,
+                self.testrun_name,
+                tp_keys
+            )
+        else:
+            tr_keys = get_testrail_keys(items)
+            self.create_test_run(
+                self.assign_user_id,
+                self.project_id,
+                self.suite_id,
+                self.testrun_name,
+                tr_keys
+            )
 
     @pytest.hookimpl(tryfirst=True, hookwrapper=True)
     def pytest_runtest_makereport(self, item, call):
@@ -106,15 +162,39 @@ class TestRailPlugin(object):
                     clean_test_ids(testcaseids),
                     get_test_outcome(outcome.result.outcome)
                 )
+        elif item.get_marker(SUITE_PREFIX):
+            _suite_id = item.get_marker(SUITE_PREFIX).kwargs.get('suite_id')
+            testcaseids = item.get_marker(SUITE_PREFIX).kwargs.get('ids')
+            if rep.when == 'call' and testcaseids:
+                self.add_suite_result(
+                    clean_suite_ids(_suite_id),
+                    clean_test_ids(testcaseids),
+                    get_test_outcome(outcome.result.outcome)
+                )
 
     def pytest_sessionfinish(self, session, exitstatus):
-        data = {'results': self.results}
-        if data['results']:
-            self.client.send_post(
-                ADD_RESULTS_URL.format(self.testrun_id),
-                data,
-                self.cert_check
-            )
+        if self.use_testplan:
+            for suite, results in self.results.iteritems():
+                data = {'results': results}
+                response = self.client.send_post(
+                    ADD_RESULTS_URL.format(self.testrun_ids[int(suite)]),
+                    data,
+                    self.cert_check
+                )
+
+                for key, _ in response[0].iteritems():
+                    if key == 'error':
+                        print('Failed to populate testrun: {}'.format(response))
+                    else:
+                        pass
+        else:
+            data = {'results': self.results}
+            if data['results']:
+                self.client.send_post(
+                    ADD_RESULTS_URL.format(self.testrun_id),
+                    data,
+                    self.cert_check
+                )
 
     # plugin
 
@@ -131,6 +211,22 @@ class TestRailPlugin(object):
                 'status_id': status,
             }
             self.results.append(data)
+
+    def add_suite_result(self, suite_id, test_ids, status):
+        """
+        Add a new result to results dict to be submitted at the end.
+
+        :param list test_id: list of test_ids.
+        :param int status: status code of test (pass or fail).
+        """
+        for test_id in test_ids:
+            data = {
+                'case_id': test_id,
+                'status_id': status,
+            }
+            if not self.results.has_key(suite_id):
+                self.results[suite_id] = []
+            self.results[suite_id].append(data)
 
     def create_test_run(
             self, assign_user_id, project_id, suite_id, testrun_name, tr_keys):
@@ -157,3 +253,43 @@ class TestRailPlugin(object):
                 print('Failed to create testrun: {}'.format(response))
             else:
                 self.testrun_id = response['id']
+
+    def create_test_plan(self, assign_user_id, project_id, testrun_name, suites_and_cases):
+        """
+        Create testrun with the suites and ids
+        :param assign_user_id:
+        :param project_id:
+        :param testrun_name:
+        :param data:
+        :return:
+        """
+        data = {
+            "name": testrun_name,
+        }
+        # add the assigned to for each section, and set include_all to false
+        entries = []
+        for id, lst in suites_and_cases.iteritems():
+            e = {
+                "suite_id": id,
+                "assignedto_id": assign_user_id,
+                "include_all": False,
+                "case_ids": suites_and_cases[id],
+            }
+            entries.append(e)
+
+        data['entries'] = entries
+
+        response = self.client.send_post(
+            ADD_TESTPLAN_URL.format(project_id),
+            data,
+            self.cert_check
+        )
+        for key, _ in response.items():
+            if key == 'error':
+                print('Failed to create testrun: {}'.format(response))
+            else:
+                # now we have to record run id by suite
+                for e in response['entries']:
+                    # there can be multiple runs, but we won't worry about that right now.
+                    self.testrun_ids[e['runs'][0]['suite_id']] = e['runs'][0]['id']
+                break

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     name='pytest-testrail',
     description='pytest plugin for creating TestRail runs and adding results',
     long_description=long_description,
-    version='0.0.11',
+    version='0.0.12',
     author='Allan Kilpatrick',
     author_email='allanklp@gmail.com',
     url='http://github.com/allankilpatrick/pytest-testrail/',

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -7,7 +7,6 @@ from pytest_testrail import plugin
 from pytest_testrail.plugin import TestRailPlugin
 from pytest_testrail.testrail_api import APIClient
 
-
 pytest_plugins = "pytester"
 
 ASSIGN_USER_ID = 3
@@ -16,6 +15,13 @@ PROJECT_ID = 4
 PYTEST_FILE = """
     from pytest_testrail.plugin import testrail
     @testrail('C1234', 'C5678')
+    def test_func():
+        pass
+"""
+
+PYTEST_SUITE_FILE = """
+    from pytest_testrail.plugin import suite_testrail
+    @suite_testrail('S12', 'C1234', 'C5678')
     def test_func():
         pass
 """
@@ -30,13 +36,34 @@ def api_client():
 
 @pytest.fixture
 def tr_plugin(api_client):
+    """
+    Creates a TestRailPlugin that is set for test run creation
+    :param api_client:
+    :return:
+    """
     return TestRailPlugin(api_client, ASSIGN_USER_ID, PROJECT_ID, SUITE_ID, True, TR_NAME)
+
+
+@pytest.fixture
+def tp_plugin(api_client):
+    """
+    Creates a TestRailPlugin that is set for test plan creation
+    :param api_client:
+    :return:
+    """
+    return TestRailPlugin(api_client, ASSIGN_USER_ID, PROJECT_ID, SUITE_ID, True, TR_NAME, True)
 
 
 @pytest.fixture
 def pytest_test_items(testdir):
     testdir.makepyfile(PYTEST_FILE)
     return [testdir.getitem(PYTEST_FILE)]
+
+
+@pytest.fixture
+def pytest_test_suite_items(testdir):
+    testdir.makepyfile(PYTEST_SUITE_FILE)
+    return [testdir.getitem(PYTEST_SUITE_FILE)]
 
 
 @freeze_time(FAKE_NOW)
@@ -57,8 +84,17 @@ def test_clean_test_ids():
     assert list(plugin.clean_test_ids(['C1234', 'C12345'])) == [1234, 12345]
 
 
+def test_clean_suite_ids():
+    assert plugin.clean_suite_ids('S1234') == 1234
+
+
 def test_get_testrail_keys(pytest_test_items, testdir):
     assert plugin.get_testrail_keys(pytest_test_items) == [1234, 5678]
+
+
+def test_get_testrail_suite_keys(pytest_test_suite_items, testdir):
+    expected = {12: [1234, 5678]}
+    assert plugin.get_testrail_suite_and_keys(pytest_test_suite_items) == expected
 
 
 def test_add_result(tr_plugin):
@@ -76,6 +112,37 @@ def test_add_result(tr_plugin):
     ]
 
     assert tr_plugin.results == expected_results
+
+
+def test_add_suite_result(tp_plugin):
+    tp_plugin.add_suite_result(1, [1, 2], 3)
+    tp_plugin.add_suite_result(1, [3], 3)
+    tp_plugin.add_suite_result(2, [4], 3)
+
+    expected_results = {
+        1: [
+            {
+                'case_id': 1,
+                'status_id': 3,
+            },
+            {
+                'case_id': 2,
+                'status_id': 3,
+            },
+            {
+                'case_id': 3,
+                'status_id': 3,
+            }
+        ],
+        2: [
+            {
+                'case_id': 4,
+                'status_id': 3,
+            }
+        ]
+    }
+
+    assert tp_plugin.results == expected_results
 
 
 def pytest_runtest_makereport(pytest_test_items, tr_plugin):
@@ -123,6 +190,30 @@ def test_create_test_run(api_client, tr_plugin):
         'assignedto_id': ASSIGN_USER_ID,
         'include_all': False,
         'case_ids': expected_tr_keys
+    }
+    check_cert = True
+    api_client.send_post.assert_called_once_with(expected_uri, expected_data, check_cert)
+
+
+def test_create_test_plan(api_client, tp_plugin):
+    expected_suite_and_keys = {1: [3453, 234234, 12],
+                               2: [123, 8, 10]}
+    expect_name = 'testrun_name'
+
+    tp_plugin.create_test_plan(ASSIGN_USER_ID, PROJECT_ID, expect_name, expected_suite_and_keys)
+    expected_uri = plugin.ADD_TESTPLAN_URL.format(PROJECT_ID)
+    expected_data = {
+        'name': 'testrun_name',
+        'entries': [
+            {'assignedto_id': 3,
+             'include_all': False,
+             'suite_id': 1,
+             'case_ids': [3453, 234234, 12]},
+            {'assignedto_id': 3,
+             'include_all': False,
+             'suite_id': 2,
+             'case_ids': [123, 8, 10]}
+        ]
     }
     check_cert = True
     api_client.send_post.assert_called_once_with(expected_uri, expected_data, check_cert)


### PR DESCRIPTION
needed to have the ability to record results across suites within the same automation run.  Quickly threw this together with a few additional tests.

I think my updates to the readme are self explanatory for how to use the change.  The existing behaviour should be unchanged. 