### PR TITLE
Allow config options to be specified either by flag or via cfg file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# Tox files
+pytests_*-test.xml

--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ Add a marker to the tests that will be picked up to be added to the run.
 	@testrail('C1234', 'C5678')
 	def test_foo():
 		# test code goes here
+	
+    # OR	
+	
+	from pytest_testrail.plugin import pytestrail
+	
+	@pytestrail.case('C1234', 'C5678')
+	def test_bar():
+	    # test code goes here
 
 Settings file template cfg:
 
@@ -43,7 +51,7 @@ Usage
 This will create a test run in TestRail, add all marked tests to run.
 Once the all tests are finished they will be updated in TestRail.
 
-	--tr_name='My Test Run'
+	--tr-testrun-name='My Test Run'
 
 Testruns can be named using the above flag, if this is not set a generated one will be used.
 ' Automation Run "timestamp" '
@@ -51,3 +59,32 @@ Testruns can be named using the above flag, if this is not set a generated one w
 	--no-ssl-cert-check
 
 This flag can be used prevent checking for a valid SSL certificate on TestRail host.
+
+Available flags:
+
+    --testrail            Create and update testruns with TestRail
+    --tr-config=TR_CONFIG
+                          Path to the config file containing information about
+                          the TestRail server (defaults to testrail.cfg)
+    --tr-url=TR_URL       TestRail address you use to access TestRail with your
+                          web browser (config file: url in API section)
+    --tr-email=TR_EMAIL   Email for the account on the TestRail server (config
+                          file: email in API section)
+    --tr-password=TR_PASSWORD
+                          Password for the account on the TestRail server
+                          (config file: password in API section)
+    --tr-testrun-assignedto-id=TR_TESTRUN_ASSIGNEDTO_ID
+                          ID of the user assigned to the test run (config file:
+                          assignedto_id in TESTRUN section)
+    --tr-testrun-project-id=TR_TESTRUN_PROJECT_ID
+                          ID of the project the test run is in (config file:
+                          project_id in TESTRUN section)
+    --tr-testrun-suite-id=TR_TESTRUN_SUITE_ID
+                          ID of the test suite containing the test cases (config
+                          file: suite_id in TESTRUN section)
+    --tr-testrun-name=TR_TESTRUN_NAME
+                          Name given to testrun, that appears in TestRail
+                          (config file: name in TESTRUN section)
+    --tr-no-ssl-cert-check
+                          Do not check for valid SSL certificate on TestRail
+                          host

--- a/pytest_testrail/conftest.py
+++ b/pytest_testrail/conftest.py
@@ -7,7 +7,7 @@ else:
     # python3
     import configparser
 
-from .plugin import TestRailPlugin
+from .plugin import PyTestRailPlugin
 from .testrail_api import APIClient
 
 
@@ -66,7 +66,7 @@ def pytest_configure(config):
                            config_manager.getoption('tr-password', 'password', 'API'))
 
         config.pluginmanager.register(
-            TestRailPlugin(
+            PyTestRailPlugin(
                 client=client,
                 assign_user_id=config_manager.getoption('tr-testrun-assignedto-id', 'assignedto_id', 'TESTRUN'),
                 project_id=config_manager.getoption('tr-testrun-project-id', 'project_id', 'TESTRUN'),

--- a/pytest_testrail/conftest.py
+++ b/pytest_testrail/conftest.py
@@ -19,39 +19,36 @@ def pytest_addoption(parser):
     group.addoption(
         '--tr-url',
         action='store',
-        help='TestRail address you use to access TestRail with your web browser')
+        help='TestRail address you use to access TestRail with your web browser (config file: url in API section)')
     group.addoption(
         '--tr-email',
         action='store',
-        help='Email for the account on the TestRail server')
+        help='Email for the account on the TestRail server (config file: email in API section)')
     group.addoption(
         '--tr-password',
         action='store',
-        help='Password for the account on the TestRail server')
+        help='Password for the account on the TestRail server (config file: password in API section)')
     group.addoption(
         '--tr-testrun-assignedto-id',
         action='store',
-        help='ID of the user assigned to the test run')
+        help='ID of the user assigned to the test run (config file: assignedto_id in TESTRUN section)')
     group.addoption(
         '--tr-testrun-project-id',
         action='store',
-        help='ID of the project the test run is in')
+        help='ID of the project the test run is in (config file: project_id in TESTRUN section)')
     group.addoption(
         '--tr-testrun-suite-id',
         action='store',
-        help='ID of the test suite containing the test cases')
-    group.addoption(
-        '--tr-no-ssl-cert-check',
-        action='store_false',
-        help='Do not check for valid SSL certificate on TestRail host'
-    )
+        help='ID of the test suite containing the test cases (config file: suite_id in TESTRUN section)')
     group.addoption(
         '--tr-testrun-name',
         action='store',
         default=None,
-        required=False,
-        help='Name given to testrun, that appears in TestRail'
-    )
+        help='Name given to testrun, that appears in TestRail (config file: name in TESTRUN section)')
+    group.addoption(
+        '--tr-no-ssl-cert-check',
+        action='store_false',
+        help='Do not check for valid SSL certificate on TestRail host')
 
 
 def pytest_configure(config):

--- a/pytest_testrail/conftest.py
+++ b/pytest_testrail/conftest.py
@@ -1,5 +1,11 @@
 import os
-import configparser
+import sys
+if sys.version_info.major == 2:
+    # python2
+    import ConfigParser as configparser
+else:
+    # python3
+    import configparser
 
 from .plugin import TestRailPlugin
 from .testrail_api import APIClient

--- a/pytest_testrail/conftest.py
+++ b/pytest_testrail/conftest.py
@@ -1,3 +1,4 @@
+import os
 import configparser
 
 from .plugin import TestRailPlugin
@@ -8,17 +9,44 @@ def pytest_addoption(parser):
     group = parser.getgroup('testrail')
     group.addoption(
         '--testrail',
-        action='store',
+        action='store_true',
         help='Create and update testruns with TestRail')
     group.addoption(
-        '--no-ssl-cert-check',
-        action='store_true',
-        default=False,
-        required=False,
+        '--tr-config',
+        action='store',
+        default='testrail.cfg',
+        help='Path to the config file containing information about the TestRail server (defaults to testrail.cfg)')
+    group.addoption(
+        '--tr-url',
+        action='store',
+        help='TestRail address you use to access TestRail with your web browser')
+    group.addoption(
+        '--tr-email',
+        action='store',
+        help='Email for the account on the TestRail server')
+    group.addoption(
+        '--tr-password',
+        action='store',
+        help='Password for the account on the TestRail server')
+    group.addoption(
+        '--tr-testrun-assignedto-id',
+        action='store',
+        help='ID of the user assigned to the test run')
+    group.addoption(
+        '--tr-testrun-project-id',
+        action='store',
+        help='ID of the project the test run is in')
+    group.addoption(
+        '--tr-testrun-suite-id',
+        action='store',
+        help='ID of the test suite containing the test cases')
+    group.addoption(
+        '--tr-no-ssl-cert-check',
+        action='store_false',
         help='Do not check for valid SSL certificate on TestRail host'
     )
     group.addoption(
-        '--tr_name',
+        '--tr-testrun-name',
         action='store',
         default=None,
         required=False,
@@ -27,30 +55,47 @@ def pytest_addoption(parser):
 
 
 def pytest_configure(config):
-    if config.option.testrail:
-        cfg_file = read_config_file(config.getoption("--testrail"))
-        client = APIClient(cfg_file.get('API', 'url'))
-        client.user = cfg_file.get('API', 'email')
-        client.password = cfg_file.get('API', 'password', raw=True)
-        ssl_cert_check = True
-        tr_name = config.getoption('--tr_name')
-
-        if config.getoption('--no-ssl-cert-check') is True:
-            ssl_cert_check = False
+    if config.getoption('--testrail'):
+        cfg_file_path = config.getoption('--tr-config')
+        config_manager = ConfigManager(cfg_file_path, config)
+        client = APIClient(config_manager.getoption('tr-url', 'url', 'API'),
+                           config_manager.getoption('tr-email', 'email', 'API'),
+                           config_manager.getoption('tr-password', 'password', 'API'))
 
         config.pluginmanager.register(
             TestRailPlugin(
                 client=client,
-                assign_user_id=cfg_file.get('TESTRUN', 'assignedto_id'),
-                project_id=cfg_file.get('TESTRUN', 'project_id'),
-                suite_id=cfg_file.get('TESTRUN', 'suite_id'),
-                cert_check=ssl_cert_check,
-                tr_name=tr_name
+                assign_user_id=config_manager.getoption('tr-testrun-assignedto-id', 'assignedto_id', 'TESTRUN'),
+                project_id=config_manager.getoption('tr-testrun-project-id', 'project_id', 'TESTRUN'),
+                suite_id=config_manager.getoption('tr-testrun-suite-id', 'suite_id', 'TESTRUN'),
+                cert_check=config_manager.getoption('tr-no-ssl-cert-check', 'no_ssl_cert_check', 'API', default=True),
+                tr_name=config_manager.getoption('tr-testrun-name', 'name', 'TESTRUN')
             )
         )
 
 
-def read_config_file(configfile):
-    config = configparser.ConfigParser()
-    config.read(configfile)
-    return config
+class ConfigManager(object):
+    def __init__(self, cfg_file_path, config):
+        '''
+        Handles retrieving configuration values. Config options set in flags are given preferance over options set in the
+        config file.
+
+        :param cfg_file_path: Path to the config file containing information about the TestRail server.
+        :type cfg_file_path: str or None
+        :param config: Config object containing commandline flag options.
+        :type config: _pytest.config.Config
+        '''
+        self.cfg_file = None
+        if os.path.isfile(cfg_file_path) or os.path.islink(cfg_file_path):
+            self.cfg_file = configparser.ConfigParser()
+            self.cfg_file.read(cfg_file_path)
+
+        self.config = config
+
+    def getoption(self, flag, cfg_name, section=None, default=None):
+        value = self.config.getoption('--{}'.format(flag))
+        if value is not None:
+            return value
+        if section is None or self.cfg_file is None:
+            return None
+        return self.cfg_file.get(section, cfg_name, fallback=None)

--- a/pytest_testrail/plugin.py
+++ b/pytest_testrail/plugin.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 import pytest
 import re
+import warnings
 
 
 PYTEST_TO_TESTRAIL_STATUS = {
@@ -15,6 +16,13 @@ TESTRAIL_PREFIX = 'testrail'
 
 ADD_RESULTS_URL = 'add_results_for_cases/{}/'
 ADD_TESTRUN_URL = 'add_run/{}'
+
+
+class DeprecatedTestDecorator(DeprecationWarning):
+    pass
+
+
+warnings.simplefilter(action='once', category=DeprecatedTestDecorator, lineno=0)
 
 
 class pytestrail(object):
@@ -42,7 +50,10 @@ def testrail(*ids):
 
     :return pytest.mark:
     """
-    return pytest.mark.testrail(ids=ids)
+    deprecation_msg = ('pytest_testrail: the @testrail decorator is deprecated and will be removed. Please use the '
+            '@pytestrail.case decorator instead.')
+    warnings.warn(deprecation_msg, DeprecatedTestDecorator)
+    return pytestrail.case(*ids)
 
 
 def get_test_outcome(outcome):

--- a/pytest_testrail/plugin.py
+++ b/pytest_testrail/plugin.py
@@ -17,6 +17,23 @@ ADD_RESULTS_URL = 'add_results_for_cases/{}/'
 ADD_TESTRUN_URL = 'add_run/{}'
 
 
+class pytestrail(object):
+    '''
+    An alternative to using the testrail function as a decorator for test cases, since py.test may confuse it as a test
+    function since it has the 'test' prefix
+    '''
+    @staticmethod
+    def case(*ids):
+        """
+        Decorator to mark tests with testcase ids.
+
+        ie. @pytestrail.case('C123', 'C12345')
+
+        :return pytest.mark:
+        """
+        return pytest.mark.testrail(ids=ids)
+
+
 def testrail(*ids):
     """
     Decorator to mark tests with testcase ids.

--- a/pytest_testrail/plugin.py
+++ b/pytest_testrail/plugin.py
@@ -84,7 +84,7 @@ def get_testrail_keys(items):
     return testcaseids
 
 
-class TestRailPlugin(object):
+class PyTestRailPlugin(object):
     def __init__(
             self, client, assign_user_id, project_id, suite_id, cert_check, tr_name):
         self.assign_user_id = assign_user_id

--- a/pytest_testrail/plugin.py
+++ b/pytest_testrail/plugin.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 import pytest
+import re
 
 
 PYTEST_TO_TESTRAIL_STATUS = {
@@ -50,7 +51,7 @@ def clean_test_ids(test_ids):
     :param list test_ids: list of test_ids.
     :return list ints: contains list of test_ids as ints.
     """
-    return map(int, [test_id.upper().replace('C', '') for test_id in test_ids])
+    return map(int, [re.search('(?P<test_id>[0-9]+$)', test_id).groupdict().get('test_id') for test_id in test_ids])
 
 
 def get_testrail_keys(items):
@@ -113,7 +114,7 @@ class TestRailPlugin(object):
             self.client.send_post(
                 ADD_RESULTS_URL.format(self.testrun_id),
                 data,
-                self.cert_check
+                cert_check=self.cert_check
             )
 
     # plugin
@@ -150,7 +151,7 @@ class TestRailPlugin(object):
         response = self.client.send_post(
             ADD_TESTRUN_URL.format(project_id),
             data,
-            self.cert_check
+            cert_check=self.cert_check
         )
         for key, _ in response.items():
             if key == 'error':

--- a/pytest_testrail/testrail_api.py
+++ b/pytest_testrail/testrail_api.py
@@ -48,7 +48,6 @@ class APIClient:
         self.cert_check = kwargs.get('cert_check', True)
         self.timeout = kwargs.get('timeout', 10.0)
 
-
     def send_get(self, uri, **kwargs):
         '''
         Send GET
@@ -79,8 +78,7 @@ class APIClient:
         )
         return r.json()
 
-
-    def send_post(self, uri, data, cert_check=True):
+    def send_post(self, uri, data, **kwargs):
         '''
         Send POST
 

--- a/pytest_testrail/testrail_api.py
+++ b/pytest_testrail/testrail_api.py
@@ -43,7 +43,7 @@ class APIClient:
         '''
         self.user = user
         self.password = password
-        self.__url = urljoin(base_url, 'index.php?/api/v2/')
+        self._url = urljoin(base_url, 'index.php?/api/v2/')
         self.headers = kwargs.get('headers', {'Content-Type': 'application/json'})
         self.cert_check = kwargs.get('cert_check', True)
         self.timeout = kwargs.get('timeout', 10.0)
@@ -68,7 +68,7 @@ class APIClient:
         cert_check = kwargs.get('cert_check', self.cert_check)
         headers = kwargs.get('headers', self.headers)
         timeout = kwargs.get('timeout', self.timeout)
-        url = urljoin(self.__url, uri)
+        url = self._url + uri
         r = requests.get(
             url,
             auth=(self.user, self.password),
@@ -100,7 +100,7 @@ class APIClient:
         cert_check = kwargs.get('cert_check', self.cert_check)
         headers = kwargs.get('headers', self.headers)
         timeout = kwargs.get('timeout', self.timeout)
-        url = urljoin(self.__url, uri)
+        url = self._url + uri
         r = requests.post(
             url,
             auth=(self.user, self.password),

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -2,4 +2,4 @@
 
 freezegun==0.3.2
 mock==1.3.0
-pytest-cov==2.2.0
+pytest-cov==2.5.1

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,15 @@
 from setuptools import setup
 
-long_description = open("README.rst").read()
+
+def read_file(fname):
+    with open(fname) as f:
+        return f.read()
+
 
 setup(
     name='pytest-testrail',
     description='pytest plugin for creating TestRail runs and adding results',
-    long_description=long_description,
+    long_description=read_file('README.rst'),
     version='0.0.11',
     author='Allan Kilpatrick',
     author_email='allanklp@gmail.com',
@@ -15,10 +19,10 @@ setup(
     ],
     package_dir={'pytest_testrail': 'pytest_testrail'},
     install_requires=[
-        'pytest>=2',
-        'configparser>=3,<4',
-        'requests==2.11.1',
-        'simplejson'
+        'pytest==3.1.2',
+        'configparser==3.5.0',
+        'requests==2.18.1',
+        'simplejson==3.11.1',
     ],
     include_package_data=True,
     entry_points={'pytest11': ['pytest-testrail = pytest_testrail.conftest']},

--- a/setup.py
+++ b/setup.py
@@ -8,20 +8,11 @@ def read_file(fname):
         return f.read()
 
 
-requirements = [
-        'pytest==3.1.2',
-        'requests==2.18.1',
-        'simplejson==3.11.1',
-]
-if sys.version_info.major == 2:
-    requirements.append('configparser==3.5.0')
-
-
 setup(
     name='pytest-testrail',
     description='pytest plugin for creating TestRail runs and adding results',
     long_description=read_file('README.rst'),
-    version='0.0.11',
+    version='1.0.0',
     author='Allan Kilpatrick',
     author_email='allanklp@gmail.com',
     url='http://github.com/allankilpatrick/pytest-testrail/',
@@ -29,7 +20,11 @@ setup(
         'pytest_testrail',
     ],
     package_dir={'pytest_testrail': 'pytest_testrail'},
-    install_requires=requirements,
+    install_requires=[
+        'pytest==3.1.2',
+        'requests==2.18.1',
+        'simplejson==3.11.1',
+    ],
     include_package_data=True,
     entry_points={'pytest11': ['pytest-testrail = pytest_testrail.conftest']},
 )

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,20 @@
+import sys
+
 from setuptools import setup
 
 
 def read_file(fname):
     with open(fname) as f:
         return f.read()
+
+
+requirements = [
+        'pytest==3.1.2',
+        'requests==2.18.1',
+        'simplejson==3.11.1',
+]
+if sys.version_info.major == 2:
+    requirements.append('configparser==3.5.0')
 
 
 setup(
@@ -18,12 +29,7 @@ setup(
         'pytest_testrail',
     ],
     package_dir={'pytest_testrail': 'pytest_testrail'},
-    install_requires=[
-        'pytest==3.1.2',
-        'configparser==3.5.0',
-        'requests==2.18.1',
-        'simplejson==3.11.1',
-    ],
+    install_requires=requirements,
     include_package_data=True,
     entry_points={'pytest11': ['pytest-testrail = pytest_testrail.conftest']},
 )

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -4,7 +4,7 @@ from mock import create_autospec, Mock
 import pytest
 
 from pytest_testrail import plugin
-from pytest_testrail.plugin import TestRailPlugin
+from pytest_testrail.plugin import PyTestRailPlugin
 from pytest_testrail.testrail_api import APIClient
 
 
@@ -30,7 +30,7 @@ def api_client():
 
 @pytest.fixture
 def tr_plugin(api_client):
-    return TestRailPlugin(api_client, ASSIGN_USER_ID, PROJECT_ID, SUITE_ID, True, TR_NAME)
+    return PyTestRailPlugin(api_client, ASSIGN_USER_ID, PROJECT_ID, SUITE_ID, True, TR_NAME)
 
 
 @pytest.fixture

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -107,7 +107,7 @@ def test_pytest_sessionfinish(api_client, tr_plugin):
     expected_uri = plugin.ADD_RESULTS_URL.format(10)
     expected_data = {'results': [1, 2]}
     check_cert = True
-    api_client.send_post.assert_called_once_with(expected_uri, expected_data, check_cert)
+    api_client.send_post.assert_called_once_with(expected_uri, expected_data, cert_check=check_cert)
 
 
 def test_create_test_run(api_client, tr_plugin):
@@ -125,4 +125,4 @@ def test_create_test_run(api_client, tr_plugin):
         'case_ids': expected_tr_keys
     }
     check_cert = True
-    api_client.send_post.assert_called_once_with(expected_uri, expected_data, check_cert)
+    api_client.send_post.assert_called_once_with(expected_uri, expected_data, cert_check=check_cert)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -14,9 +14,13 @@ ASSIGN_USER_ID = 3
 FAKE_NOW = datetime(2015, 1, 31, 19, 5, 42)
 PROJECT_ID = 4
 PYTEST_FILE = """
-    from pytest_testrail.plugin import testrail
+    from pytest_testrail.plugin import testrail, pytestrail
     @testrail('C1234', 'C5678')
     def test_func():
+        pass
+
+    @pytestrail.case('C8765', 'C4321')
+    def test_other_func():
         pass
 """
 SUITE_ID = 1
@@ -36,7 +40,7 @@ def tr_plugin(api_client):
 @pytest.fixture
 def pytest_test_items(testdir):
     testdir.makepyfile(PYTEST_FILE)
-    return [testdir.getitem(PYTEST_FILE)]
+    return [item for item in testdir.getitems(PYTEST_FILE) if item.name != 'testrail']
 
 
 @freeze_time(FAKE_NOW)
@@ -58,7 +62,7 @@ def test_clean_test_ids():
 
 
 def test_get_testrail_keys(pytest_test_items, testdir):
-    assert plugin.get_testrail_keys(pytest_test_items) == [1234, 5678]
+    assert plugin.get_testrail_keys(pytest_test_items) == [1234, 5678, 8765, 4321]
 
 
 def test_add_result(tr_plugin):
@@ -78,7 +82,7 @@ def test_add_result(tr_plugin):
     assert tr_plugin.results == expected_results
 
 
-def pytest_runtest_makereport(pytest_test_items, tr_plugin):
+def pytest_runtest_makereport(tr_plugin):
     keys = ['C4354', 'C1234']
     report = Mock(keywords={key: None for key in keys}, failed=True, when='teardown')
 


### PR DESCRIPTION
This PR mainly allows anything that could be set in the config file to be set through command line flags. I prefer not to have login credentials written to a file anywhere so this helps me avoid that. Each command line flag, except for `--testrail` and `--tr-config`, can also be set in the config file, but command line flags override config file values.

I also added the `pytestrail` class which has a static method `case` that's equivalent to the `testrail` function in the plugin module. I noticed that py.test was collecting `testrail` as a test (presumably because of the 'test' prefix, although the py.test documentation says it looks for a 'test_' prefix), and this fix worked nicely.