### PR TITLE
Fix issue #33: Exception when TestRail API returns a 429 HTTP status

### DIFF
--- a/pytest_testrail/testrail_api.py
+++ b/pytest_testrail/testrail_api.py
@@ -82,7 +82,7 @@ class APIClient:
             pause = int(r.headers.get('Retry-After', 60))
             print("Too many requests: pause for {}s".format(pause))
             time.sleep(pause)
-            self.send_get(uri,**kwargs)
+            return self.send_get(uri,**kwargs)
         else:
             return r.json()
 
@@ -122,7 +122,7 @@ class APIClient:
             pause = int(r.headers.get('Retry-After', 60))
             print("Too many requests: pause for {}s".format(pause))
             time.sleep(pause)
-            self.send_post(uri, data, **kwargs)
+            return self.send_post(uri, data, **kwargs)
         else:
             return r.json()
 

--- a/pytest_testrail/testrail_api.py
+++ b/pytest_testrail/testrail_api.py
@@ -13,6 +13,7 @@
 
 import sys
 import requests
+import time
 
 if sys.version_info.major == 2:
     from urlparse import urljoin
@@ -76,7 +77,14 @@ class APIClient:
             verify=cert_check,
             timeout=timeout
         )
-        return r.json()
+
+        if r.status_code == 429:  # Too many requests
+            pause = int(r.headers.get('Retry-After', 60))
+            print("Too many requests: pause for {}s".format(pause))
+            time.sleep(pause)
+            self.send_get(uri,**kwargs)
+        else:
+            return r.json()
 
     def send_post(self, uri, data, **kwargs):
         '''
@@ -109,7 +117,14 @@ class APIClient:
             verify=cert_check,
             timeout=timeout
         )
-        return r.json()
+
+        if r.status_code == 429:  # Too many requests
+            pause = int(r.headers.get('Retry-After', 60))
+            print("Too many requests: pause for {}s".format(pause))
+            time.sleep(pause)
+            self.send_post(uri, data, **kwargs)
+        else:
+            return r.json()
 
     @staticmethod
     def get_error(json_response):


### PR DESCRIPTION
Fix Issue #33: Exception when TestRail API returns a 429 HTTP status

I choose to use the header parameter 'Retry-After' to allow the publishing to continue.